### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/orgs-sorted.yml
+++ b/.github/workflows/orgs-sorted.yml
@@ -1,5 +1,8 @@
 name: Ensure orgs.txt is sorted
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/stldevs/stldevs/security/code-scanning/6](https://github.com/stldevs/stldevs/security/code-scanning/6)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only needs to read the contents of the repository to check if a file is sorted, we will set `contents: read` as the minimal required permission. This change ensures that the workflow adheres to the principle of least privilege and avoids unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
